### PR TITLE
Updated platform version in podspec

### DIFF
--- a/TSMessages.podspec
+++ b/TSMessages.podspec
@@ -23,7 +23,7 @@ There are 4 different types already set up for you: Success, Error, Warning, Mes
   s.source           = { :git => "https://github.com/KrauseFx/TSMessages.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/KrauseFx'
 
-  s.platform     = :ios, '5.0'
+  s.platform     = :ios, '7.0'
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes'


### PR DESCRIPTION
Needed in order to use <code>edgesForExtendedLayout</code> (introduced in iOS 7.0)
